### PR TITLE
Swap the two println fields filename and fienode

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		_, err = fmt.Println(filename, fienode)
+		_, err = fmt.Println(fienode, filename)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
In shell scripts, it's easer this way to separate the checksum from the filename. And it's the same format as for example md5sum and sha1sum